### PR TITLE
feat(event): read controller's events #5

### DIFF
--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -27,4 +27,16 @@
     "request": "launch",
     "sourceLanguages": ["rust"],
   },
+  {
+    "label": "Debug read /dev/input/event25",
+    "adapter": "CodeLLDB",
+    "build": {
+      "command": "cargo",
+      "args": ["build"],
+    },
+    "program": "target/debug/blazeremap",
+    "args": ["read", "/dev/input/event25"],
+    "request": "launch",
+    "sourceLanguages": ["rust"],
+  },
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitvec"
@@ -124,8 +124,6 @@ dependencies = [
  "evdev",
  "mockall",
  "predicates",
- "serde",
- "serde_json",
  "thiserror",
  "toml",
  "tracing-subscriber",
@@ -143,20 +141,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "cc"
-version = "1.2.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -280,22 +274,15 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "evdev"
-version = "0.12.2"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6055a93a963297befb0f4f6e18f314aec9767a4bbe88b151126df2433610a7"
+checksum = "25b686663ba7f08d92880ff6ba22170f1df4e83629341cba34cf82cd65ebea99"
 dependencies = [
  "bitvec",
  "cfg-if",
  "libc",
  "nix",
- "thiserror",
 ]
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "float-cmp"
@@ -347,12 +334,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "itoa"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,15 +367,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mockall"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,15 +394,14 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if",
+ "cfg_aliases",
  "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -565,7 +536,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
- "serde_derive",
 ]
 
 [[package]]
@@ -589,19 +559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,12 +575,6 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "smallvec"
@@ -833,9 +784,3 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
-
-[[package]]
-name = "zmij"
-version = "1.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,14 +29,12 @@ anyhow = "1.0"          # Simple error handling
 thiserror = "1.0"       # Custom error types
 
 # Evdev
-evdev = "0.12"          # Main evdev library
+evdev = "0.13.2"          # Main evdev library
 
 # Logging
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
-# Serialization
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+
 
 # Threading utilities
 crossbeam = "0.8.4"     # For channels

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,6 @@
 // CLI module - command definitions and handling
 mod detect;
+mod read;
 
 use clap::Command;
 
@@ -12,6 +13,7 @@ pub fn build_cli() -> Command {
         .subcommand_required(true)
         .arg_required_else_help(true)
         .subcommand(detect::command())
+        .subcommand(read::command())
 }
 
 /// Execute the CLI and handle the result
@@ -20,6 +22,7 @@ pub fn execute() -> anyhow::Result<()> {
 
     match matches.subcommand() {
         Some(("detect", sub_matches)) => detect::handle(sub_matches),
+        Some(("read", sub_matches)) => read::handle(sub_matches),
         _ => unreachable!("Subcommand required"),
     }
 }

--- a/src/cli/read.rs
+++ b/src/cli/read.rs
@@ -1,0 +1,89 @@
+use std::time::Instant;
+
+use crate::device::controller::Controller;
+use crate::platform::linux::LinuxController;
+use anyhow::Result;
+use clap::Command;
+
+pub fn command() -> Command {
+    Command::new("read").about("Read and display controller events (debugging)").arg(
+        clap::Arg::new("device")
+            .help("Device path (e.g., /dev/input/event3)")
+            .required(true)
+            .index(1),
+    )
+}
+
+pub fn handle(matches: &clap::ArgMatches) -> Result<()> {
+    let device_path = matches.get_one::<String>("device").unwrap();
+
+    println!("Opening device: {}", device_path);
+    let mut controller = LinuxController::open(device_path)?;
+
+    println!("Reading events (Ctrl+C to stop)...\n");
+    println!("Format: [elapsed since first event][Δ from previous] Event\n");
+
+    let mut first_event_timestamp: Option<Instant> = None;
+    let mut last_timestamp: Option<Instant> = None;
+
+    loop {
+        match controller.read_event()? {
+            Some(event) => {
+                if !matches!(event, crate::event::InputEvent::Sync { .. }) {
+                    let timestamp = event.timestamp();
+
+                    // Initialize start time on the first actual event received
+                    let first = *first_event_timestamp.get_or_insert(timestamp);
+                    let elapsed = timestamp.saturating_duration_since(first);
+
+                    // Calculate delta from previous event
+                    let delta = if let Some(last) = last_timestamp {
+                        timestamp.saturating_duration_since(last).as_micros()
+                    } else {
+                        0
+                    };
+
+                    println!(
+                        "[{:>8.5}ms][Δ {:>8}µs] {}",
+                        elapsed.as_secs_f64() * 1000.0,
+                        delta,
+                        event
+                    );
+
+                    last_timestamp = Some(timestamp);
+                }
+            }
+            None => {
+                println!("Device disconnected");
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_command_structure() {
+        let cmd = command();
+        assert_eq!(cmd.get_name(), "read");
+        assert!(cmd.get_about().unwrap().to_string().contains("debugging"));
+    }
+
+    #[test]
+    fn test_command_has_required_device_arg() {
+        let cmd = command();
+
+        // Check that device argument exists
+        let device_arg = cmd.get_arguments().find(|arg| arg.get_id() == "device");
+        assert!(device_arg.is_some());
+
+        let device_arg = device_arg.unwrap();
+        assert!(device_arg.is_required_set());
+        assert!(device_arg.get_help().unwrap().to_string().contains("/dev/input/event"));
+    }
+}

--- a/src/device/controller/info.rs
+++ b/src/device/controller/info.rs
@@ -1,5 +1,4 @@
-// Controller information and trait definition
-
+// Controller information
 use super::types::{ControllerCapability, ControllerType};
 
 /// Information about a detected controller
@@ -12,13 +11,4 @@ pub struct ControllerInfo {
     pub vendor_name: String,
     pub product_id: u16,
     pub capabilities: Vec<ControllerCapability>,
-}
-
-/// Controller trait - represents a physical game controller
-pub trait Controller {
-    /// Get detailed info about the controller
-    fn get_info(&self) -> &ControllerInfo;
-
-    /// Close releases the device
-    fn close(self) -> anyhow::Result<()>;
 }

--- a/src/device/controller/mod.rs
+++ b/src/device/controller/mod.rs
@@ -1,10 +1,24 @@
 // Controller module
 
+// pub mod controller;
 pub mod database;
 pub mod info;
 pub mod types;
 
 // Re-export commonly used types
+// pub use controller::Controller;
 pub use database::{get_known_vendor_database, identify_controller};
-pub use info::{Controller, ControllerInfo};
+pub use info::ControllerInfo;
 pub use types::{ControllerCapability, ControllerType, capabilities_to_strings};
+
+pub trait Controller {
+    /// Get detailed info about the controller
+    fn get_info(&self) -> &ControllerInfo;
+
+    /// Read the next input event (BLOCKING)
+    /// Returns None when device is disconnected
+    fn read_event(&mut self) -> anyhow::Result<Option<crate::event::InputEvent>>;
+
+    /// Close releases the device
+    fn close(self) -> anyhow::Result<()>;
+}

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,6 +1,4 @@
 // Device module
-// Mirrors: internal/device/ package
-
 pub mod controller;
 pub mod manager;
 

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -5,3 +5,107 @@
 mod types;
 
 pub use types::*;
+
+#[cfg(target_os = "linux")]
+use std::sync::OnceLock;
+use std::time::{Instant, SystemTime};
+
+/// Global time anchor for converting SystemTime to Instant
+static TIME_ANCHOR: OnceLock<TimeAnchor> = OnceLock::new();
+
+#[derive(Clone, Copy)]
+struct TimeAnchor {
+    system_time: SystemTime,
+    instant: Instant,
+}
+
+impl TimeAnchor {
+    fn new() -> Self {
+        Self { system_time: SystemTime::now(), instant: Instant::now() }
+    }
+
+    /// Convert SystemTime to Instant using this anchor
+    fn to_instant(self, system_time: SystemTime) -> Instant {
+        match system_time.duration_since(self.system_time) {
+            Ok(duration) => self.instant + duration,
+            Err(err) => self.instant - err.duration(),
+        }
+    }
+}
+
+/// Initialize the global time anchor (call once at startup)
+///
+/// This should be called early in main() before any event processing.
+/// It establishes a fixed point for converting platform-specific timestamps
+/// to monotonic Instant values.
+pub fn init_time_anchor() {
+    TIME_ANCHOR.get_or_init(TimeAnchor::new);
+}
+
+/// Convert a SystemTime to Instant (internal helper)
+pub(crate) fn system_time_to_instant(system_time: SystemTime) -> Instant {
+    let anchor = TIME_ANCHOR.get_or_init(TimeAnchor::new);
+    anchor.to_instant(system_time)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    #[test]
+    fn test_time_anchor_conversion() {
+        let anchor_sys = SystemTime::now();
+        let anchor_inst = Instant::now();
+        let anchor = TimeAnchor { system_time: anchor_sys, instant: anchor_inst };
+
+        // Test future time (relative duration should be preserved)
+        let future_sys = anchor_sys + Duration::from_millis(100);
+        let future_inst = anchor.to_instant(future_sys);
+        assert!(future_inst > anchor_inst);
+        assert_eq!(future_inst.duration_since(anchor_inst), Duration::from_millis(100));
+
+        // Test past time (handling negative deltas correctly)
+        let past_sys = anchor_sys - Duration::from_millis(50);
+        let past_inst = anchor.to_instant(past_sys);
+        assert!(past_inst < anchor_inst);
+        assert_eq!(anchor_inst.duration_since(past_inst), Duration::from_millis(50));
+
+        // Test exact anchor time
+        assert_eq!(anchor.to_instant(anchor_sys), anchor_inst);
+    }
+
+    #[test]
+    fn test_global_system_time_to_instant() {
+        // Ensure anchor is initialized
+        init_time_anchor();
+
+        let now_sys = SystemTime::now();
+        let inst1 = system_time_to_instant(now_sys);
+
+        // Wait a bit to simulate event gap
+        std::thread::sleep(Duration::from_millis(10));
+
+        let later_sys = SystemTime::now();
+        let inst2 = system_time_to_instant(later_sys);
+
+        // The duration between Instants should match the duration between SystemTimes
+        let sys_duration = later_sys.duration_since(now_sys).unwrap_or(Duration::ZERO);
+        let inst_duration = inst2.saturating_duration_since(inst1);
+
+        // Allow for tiny discrepancies (under 500µs) due to clock precision/jitter under load
+        let diff = if inst_duration > sys_duration {
+            inst_duration - sys_duration
+        } else {
+            sys_duration - inst_duration
+        };
+
+        assert!(
+            diff < Duration::from_micros(500),
+            "Duration mismatch: expected {:?}, got {:?} (diff: {:?})",
+            sys_duration,
+            inst_duration,
+            diff
+        );
+    }
+}

--- a/src/event/types.rs
+++ b/src/event/types.rs
@@ -1,29 +1,38 @@
 /*
-  Event type definitions for controller input processing.
+ Event type definitions for controller input processing.
 
-   This module defines the core event types used throughout BlazeRemap for
-   representing controller inputs and their mapped outputs.
+  This module defines the core event types used throughout BlazeRemap for
+  representing controller inputs and their mapped outputs.
 
-   # Event Flow
-   Physical Controller → InputEvent → Mapping Engine → OutputEvent → Virtual Device
+  # Event Flow
+  Physical Controller → InputEvent → Mapping Engine → OutputEvent → Virtual Device
 
-   # Types
-   - [`InputEvent`]: Represents a raw input from a physical controller (button press,
-       axis movement, etc.). Timestamps use [`Instant`] for monotonic, high-precision
-       latency measurement.
-   - [`OutputEvent`]: Represents a mapped output event (keyboard key, mouse button,
-       etc.) that will be emitted to a virtual device.
-   - [`EventType`]: Categorizes input events (Button, Axis, DPad, Sync).
-   - [`OutputType`]: Categorizes output events (Keyboard, Mouse, Gamepad).
+  # Types
+  - [`InputEvent`]: Represents a raw input from a physical controller (button press,
+      axis movement, etc.). Timestamps use [`Instant`] for monotonic, high-precision
+      latency measurement.
+  - [`OutputEvent`]: Represents a mapped output event (keyboard key, mouse button,
+      etc.) that will be emitted to a virtual device.
+  - [`EventType`]: Categorizes input events (Button, Axis, DPad, Sync).
+  - [`OutputType`]: Categorizes output events (Keyboard, Mouse, Gamepad).
+  - [`ButtonCode`]: Platform-agnostic gamepad button codes.
+  - [`AxisCode`]: Platform-agnostic gamepad axis codes.
 
-   # Timestamps
-   All [`InputEvent`]s use [`Instant`] timestamps captured when the event is created
-   in userspace (not the kernel timestamp). This provides:
-   - Monotonic timing (immune to system clock adjustments)
-   - High precision for sub-millisecond latency measurement
-   - Simple API for calculating elapsed time
+  # Timestamps
+  All [`InputEvent`]s use [`Instant`] timestamps. For raw physical events, these are
+  converted from kernel timestamps using a global anchor to preserve relative timing.
+  This provides:
+  - Monotonic timing (immune to system clock adjustments)
+
+  - High precision for sub-millisecond latency measurement
+  - Simple API for calculating elapsed time
+
+  # Platform Abstraction
+  The [`ButtonCode`] and [`AxisCode`] enums provide a platform-agnostic representation
+  of gamepad inputs. They map platform-specific codes (like Linux evdev codes) to
+  a common domain model that works across platforms and controller types.
 */
-use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::time::Instant;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -34,65 +43,215 @@ pub enum EventType {
     Sync,
 }
 
-#[derive(Debug, Copy, Clone)] // Changed: Copy instead of just Clone
-pub struct InputEvent {
-    pub event_type: EventType,
-    pub code: u16,
-    pub value: i32,
-    pub timestamp: Instant,
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ButtonCode {
+    South,
+    East,
+    North,
+    West,
+    LeftShoulder,
+    RightShoulder,
+    LeftTrigger,
+    RightTrigger,
+    Select,
+    Start,
+    LeftStick,
+    RightStick,
+    DPadUp,
+    DPadDown,
+    DPadLeft,
+    DPadRight,
+    Mode,
+    Misc1,
+    Paddle1,
+    Paddle2,
+    Paddle3,
+    Paddle4,
+    Touchpad,
+    Unknown,
+}
+
+impl fmt::Display for ButtonCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::South => write!(f, "South"),
+            Self::East => write!(f, "East"),
+            Self::North => write!(f, "North"),
+            Self::West => write!(f, "West"),
+            Self::LeftShoulder => write!(f, "Left Shoulder"),
+            Self::RightShoulder => write!(f, "Right Shoulder"),
+            Self::LeftTrigger => write!(f, "Left Trigger"),
+            Self::RightTrigger => write!(f, "Right Trigger"),
+            Self::Select => write!(f, "Select"),
+            Self::Start => write!(f, "Start"),
+            Self::LeftStick => write!(f, "Left Stick"),
+            Self::RightStick => write!(f, "Right Stick"),
+            Self::DPadUp => write!(f, "DPad Up"),
+            Self::DPadDown => write!(f, "DPad Down"),
+            Self::DPadLeft => write!(f, "DPad Left"),
+            Self::DPadRight => write!(f, "DPad Right"),
+            Self::Mode => write!(f, "Mode"),
+            Self::Misc1 => write!(f, "Misc"),
+            Self::Paddle1 => write!(f, "Paddle 1"),
+            Self::Paddle2 => write!(f, "Paddle 2"),
+            Self::Paddle3 => write!(f, "Paddle 3"),
+            Self::Paddle4 => write!(f, "Paddle 4"),
+            Self::Touchpad => write!(f, "Touchpad"),
+            Self::Unknown => write!(f, "Unknown"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AxisCode {
+    LeftX,
+    LeftY,
+    RightX,
+    RightY,
+    LeftTrigger,
+    RightTrigger,
+    DPadX,
+    DPadY,
+    Unknown,
+}
+
+impl fmt::Display for AxisCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::LeftX => write!(f, "Left X"),
+            Self::LeftY => write!(f, "Left Y"),
+            Self::RightX => write!(f, "Right X"),
+            Self::RightY => write!(f, "Right Y"),
+            Self::LeftTrigger => write!(f, "Left Trigger"),
+            Self::RightTrigger => write!(f, "Right Trigger"),
+            Self::DPadX => write!(f, "DPad X"),
+            Self::DPadY => write!(f, "DPad Y"),
+            Self::Unknown => write!(f, "Unknown"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)] // Copy for performance in event loops
+pub enum InputEvent {
+    Button {
+        code: ButtonCode,
+        pressed: bool, // true = press, false = release
+        timestamp: Instant,
+    },
+    Axis {
+        code: AxisCode,
+        value: i32,
+        timestamp: Instant,
+    },
+    Sync {
+        timestamp: Instant,
+    },
 }
 
 impl InputEvent {
     // For production code - captures current time
-    pub fn button_press(code: u16) -> Self {
-        Self { event_type: EventType::Button, code, value: 1, timestamp: Instant::now() }
+    pub fn button_press(button_code: ButtonCode) -> Self {
+        Self::Button { code: button_code, pressed: true, timestamp: Instant::now() }
     }
 
-    pub fn button_release(code: u16) -> Self {
-        Self { event_type: EventType::Button, code, value: 0, timestamp: Instant::now() }
+    pub fn button_release(button_code: ButtonCode) -> Self {
+        Self::Button { code: button_code, pressed: false, timestamp: Instant::now() }
     }
 
-    pub fn axis_move(code: u16, value: i32) -> Self {
-        Self { event_type: EventType::Axis, code, value, timestamp: Instant::now() }
+    pub fn axis_move(axis_code: AxisCode, value: i32) -> Self {
+        Self::Axis { code: axis_code, value, timestamp: Instant::now() }
+    }
+
+    pub fn sync() -> Self {
+        Self::Sync { timestamp: Instant::now() }
+    }
+
+    // Method to ignore for Sony DualShock4 analog sticks
+    // implement a dead zone to ignore small movements near center
+    pub fn is_in_deadzone(&self) -> bool {
+        const ANALOG_CENTER: i32 = 128; // For 0-255 range
+        const DEAD_ZONE: i32 = 10; // ±10 from center = ignore
+
+        match self {
+            Self::Axis { code, value, .. } => {
+                // Don't apply deadzone to triggers (they have different ranges)
+                if matches!(code, AxisCode::LeftTrigger | AxisCode::RightTrigger) {
+                    return false;
+                }
+
+                let distance_from_center = (value - ANALOG_CENTER).abs();
+                distance_from_center <= DEAD_ZONE
+            }
+            _ => false, // Only axis events can be in deadzone
+        }
     }
 
     // For testing - allows providing a specific timestamp
     #[cfg(test)]
-    pub fn button_press_at(code: u16, timestamp: Instant) -> Self {
-        Self { event_type: EventType::Button, code, value: 1, timestamp }
+    pub fn button_press_at(button_code: ButtonCode, timestamp: Instant) -> Self {
+        Self::Button { code: button_code, pressed: true, timestamp }
     }
 
     #[cfg(test)]
-    pub fn button_release_at(code: u16, timestamp: Instant) -> Self {
-        Self { event_type: EventType::Button, code, value: 0, timestamp }
+    pub fn button_release_at(button_code: ButtonCode, timestamp: Instant) -> Self {
+        Self::Button { code: button_code, pressed: false, timestamp }
     }
 
     #[cfg(test)]
-    pub fn axis_move_at(code: u16, value: i32, timestamp: Instant) -> Self {
-        Self { event_type: EventType::Axis, code, value, timestamp }
+    pub fn axis_move_at(axis_code: AxisCode, value: i32, timestamp: Instant) -> Self {
+        Self::Axis { code: axis_code, value, timestamp }
+    }
+
+    #[cfg(test)]
+    pub fn sync_at(timestamp: Instant) -> Self {
+        Self::Sync { timestamp }
     }
 
     pub fn is_button_pressed(&self) -> bool {
-        self.event_type == EventType::Button && self.value > 0
+        matches!(self, Self::Button { pressed: true, .. })
     }
 
     pub fn is_button_released(&self) -> bool {
-        self.event_type == EventType::Button && self.value == 0
+        matches!(self, Self::Button { pressed: false, .. })
     }
 
     pub fn is_axis_moved(&self) -> bool {
-        self.event_type == EventType::Axis
+        matches!(self, Self::Axis { .. })
+    }
+
+    pub fn timestamp(&self) -> Instant {
+        match self {
+            Self::Button { timestamp, .. } => *timestamp,
+            Self::Axis { timestamp, .. } => *timestamp,
+            Self::Sync { timestamp } => *timestamp,
+        }
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+impl fmt::Display for InputEvent {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Button { code, pressed, .. } => {
+                write!(f, "{} ({})", code, if *pressed { "pressed" } else { "released" })
+            }
+            Self::Axis { code, value, .. } => {
+                write!(f, "{}: {}", code, value)
+            }
+            Self::Sync { .. } => {
+                write!(f, "Sync")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct OutputEvent {
     pub output_type: OutputType,
     pub code: u16,
     pub value: i32,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OutputType {
     Keyboard,
     Mouse,
@@ -117,42 +276,41 @@ mod tests {
 
     #[test]
     fn test_button_press_event() {
-        let event = InputEvent::button_press(304);
-        assert_eq!(event.event_type, EventType::Button);
-        assert_eq!(event.code, 304);
-        assert_eq!(event.value, 1);
+        let event = InputEvent::button_press(ButtonCode::South);
         assert!(event.is_button_pressed());
         assert!(!event.is_button_released());
+        assert!(!event.is_axis_moved());
+        assert!(!event.is_in_deadzone());
     }
 
     #[test]
     fn test_button_release_event() {
-        let event = InputEvent::button_release(304);
-        assert_eq!(event.value, 0);
+        let event = InputEvent::button_release(ButtonCode::South);
         assert!(!event.is_button_pressed());
         assert!(event.is_button_released());
+        assert!(!event.is_axis_moved());
     }
 
     #[test]
     fn test_axis_event() {
-        let event = InputEvent::axis_move(0, 15234);
-        assert_eq!(event.event_type, EventType::Axis);
-        assert_eq!(event.value, 15234);
+        let event = InputEvent::axis_move(AxisCode::LeftX, 15234);
+        assert!(!event.is_button_pressed());
+        assert!(!event.is_button_released());
         assert!(event.is_axis_moved());
     }
 
     #[test]
     fn test_latency_calculation() {
         // Use actual timing with Instant
-        let press = InputEvent::button_press(304);
+        let press = InputEvent::button_press(ButtonCode::South);
 
         // Simulate small delay
         thread::sleep(Duration::from_millis(5));
 
-        let release = InputEvent::button_release(304);
+        let release = InputEvent::button_release(ButtonCode::South);
 
         // Calculate actual elapsed time
-        let latency = release.timestamp.duration_since(press.timestamp);
+        let latency = release.timestamp().duration_since(press.timestamp());
 
         // Should be at least 5ms (might be slightly more due to scheduler)
         assert!(latency >= Duration::from_millis(5));
@@ -162,11 +320,11 @@ mod tests {
     #[test]
     fn test_timestamp_ordering() {
         // Create events in sequence
-        let event1 = InputEvent::button_press(304);
-        let event2 = InputEvent::button_press(305);
+        let event1 = InputEvent::button_press(ButtonCode::South);
+        let event2 = InputEvent::button_press(ButtonCode::East);
 
         // Second event should have later or equal timestamp
-        assert!(event2.timestamp >= event1.timestamp);
+        assert!(event2.timestamp() >= event1.timestamp());
     }
 
     #[test]
@@ -176,32 +334,124 @@ mod tests {
         let ts1 = base;
         let ts2 = base + Duration::from_millis(10);
 
-        let press = InputEvent::button_press_at(304, ts1);
-        let release = InputEvent::button_release_at(304, ts2);
+        let press = InputEvent::button_press_at(ButtonCode::South, ts1);
+        let release = InputEvent::button_release_at(ButtonCode::South, ts2);
 
-        let latency = release.timestamp.duration_since(press.timestamp);
+        let latency = release.timestamp().duration_since(press.timestamp());
         assert_eq!(latency, Duration::from_millis(10));
     }
 
     #[test]
     fn test_elapsed_since_event() {
-        let event = InputEvent::button_press(304);
+        let event = InputEvent::button_press(ButtonCode::South);
 
         // Wait a bit
         thread::sleep(Duration::from_millis(10));
 
         // Check how much time has elapsed since event
-        let elapsed = event.timestamp.elapsed();
+        let elapsed = event.timestamp().elapsed();
         assert!(elapsed >= Duration::from_millis(10));
     }
 
     #[test]
     fn test_copy_trait() {
-        let event1 = InputEvent::button_press(304);
+        let event1 = InputEvent::button_press(ButtonCode::South);
         let event2 = event1; // Copy (not move)
 
-        // Both should be usable
-        assert_eq!(event1.code, 304);
-        assert_eq!(event2.code, 304);
+        // Both should be usable (Copy trait allows this)
+        assert!(event1.is_button_pressed());
+        assert!(event2.is_button_pressed());
+    }
+
+    #[test]
+    fn test_button_code_display() {
+        assert_eq!(ButtonCode::South.to_string(), "South");
+        assert_eq!(ButtonCode::East.to_string(), "East");
+        assert_eq!(ButtonCode::North.to_string(), "North");
+        assert_eq!(ButtonCode::West.to_string(), "West");
+        assert_eq!(ButtonCode::LeftShoulder.to_string(), "Left Shoulder");
+        assert_eq!(ButtonCode::RightShoulder.to_string(), "Right Shoulder");
+        assert_eq!(ButtonCode::LeftTrigger.to_string(), "Left Trigger");
+        assert_eq!(ButtonCode::RightTrigger.to_string(), "Right Trigger");
+        assert_eq!(ButtonCode::LeftStick.to_string(), "Left Stick");
+        assert_eq!(ButtonCode::RightStick.to_string(), "Right Stick");
+        assert_eq!(ButtonCode::DPadUp.to_string(), "DPad Up");
+    }
+
+    #[test]
+    fn test_axis_code_display() {
+        assert_eq!(AxisCode::LeftX.to_string(), "Left X");
+        assert_eq!(AxisCode::LeftY.to_string(), "Left Y");
+        assert_eq!(AxisCode::RightX.to_string(), "Right X");
+        assert_eq!(AxisCode::RightY.to_string(), "Right Y");
+        assert_eq!(AxisCode::LeftTrigger.to_string(), "Left Trigger");
+        assert_eq!(AxisCode::RightTrigger.to_string(), "Right Trigger");
+        assert_eq!(AxisCode::DPadX.to_string(), "DPad X");
+        assert_eq!(AxisCode::DPadY.to_string(), "DPad Y");
+    }
+
+    #[test]
+    fn test_input_event_display() {
+        let button_event = InputEvent::button_press(ButtonCode::South);
+        assert_eq!(format!("{}", button_event), "South (pressed)");
+
+        let release_event = InputEvent::button_release(ButtonCode::South);
+        assert_eq!(format!("{}", release_event), "South (released)");
+
+        let axis_event = InputEvent::axis_move(AxisCode::LeftX, 12345);
+        assert_eq!(format!("{}", axis_event), "Left X: 12345");
+
+        let sync_event = InputEvent::sync();
+        assert_eq!(format!("{}", sync_event), "Sync");
+    }
+
+    #[test]
+    fn test_is_in_deadzone() {
+        // Test axis events within deadzone
+        let center_event = InputEvent::axis_move(AxisCode::LeftX, 128);
+        assert!(center_event.is_in_deadzone());
+
+        let near_center_event = InputEvent::axis_move(AxisCode::LeftX, 125);
+        assert!(near_center_event.is_in_deadzone());
+
+        let boundary_low = InputEvent::axis_move(AxisCode::LeftX, 118);
+        assert!(boundary_low.is_in_deadzone());
+
+        let boundary_high = InputEvent::axis_move(AxisCode::LeftX, 138);
+        assert!(boundary_high.is_in_deadzone());
+
+        // Test axis events outside deadzone
+        let outside_low = InputEvent::axis_move(AxisCode::LeftX, 110);
+        assert!(!outside_low.is_in_deadzone());
+
+        let outside_high = InputEvent::axis_move(AxisCode::LeftX, 150);
+        assert!(!outside_high.is_in_deadzone());
+
+        // Test that triggers are never in deadzone (even at center)
+        let trigger_center = InputEvent::axis_move(AxisCode::LeftTrigger, 128);
+        assert!(!trigger_center.is_in_deadzone());
+
+        // Test that non-axis events are not in deadzone
+        let button_event = InputEvent::button_press(ButtonCode::South);
+        assert!(!button_event.is_in_deadzone());
+
+        let sync_event = InputEvent::sync();
+        assert!(!sync_event.is_in_deadzone());
+    }
+
+    #[test]
+    fn test_deadzone_boundary_cases() {
+        // Test exact deadzone boundaries (±10 from center)
+        let deadzone_min = InputEvent::axis_move(AxisCode::LeftX, 128 - 10);
+        assert!(deadzone_min.is_in_deadzone());
+
+        let deadzone_max = InputEvent::axis_move(AxisCode::LeftX, 128 + 10);
+        assert!(deadzone_max.is_in_deadzone());
+
+        let just_outside_min = InputEvent::axis_move(AxisCode::LeftX, 128 - 11);
+        assert!(!just_outside_min.is_in_deadzone());
+
+        let just_outside_max = InputEvent::axis_move(AxisCode::LeftX, 128 + 11);
+        assert!(!just_outside_max.is_in_deadzone());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,13 @@
 // Binary entry point for BlazeRemap
 use blazeremap::app::App;
+use blazeremap::event::init_time_anchor;
 use std::process;
 
 fn main() {
     // Initialize logging
     tracing_subscriber::fmt::init();
+
+    init_time_anchor();
 
     // Run the app and exit with appropriate code
     process::exit(run());

--- a/src/platform/linux/converter.rs
+++ b/src/platform/linux/converter.rs
@@ -1,133 +1,240 @@
 /*
-  Conversion utilities for translating evdev events to domain events.
+Conversion utilities for translating evdev events to domain events.
 
-   This module provides converters that transform platform-specific event types
-   (from the Linux evdev subsystem) into BlazeRemap's platform-agnostic event types.
+ This module provides converters that transform platform-specific event types
+ (from the Linux evdev subsystem) into BlazeRemap's platform-agnostic event types.
 
-   # Purpose
-   The converter acts as a boundary layer between the Linux input subsystem and
-   BlazeRemap's core logic, allowing the rest of the application to work with
-   clean, domain-specific types regardless of the underlying platform.
+ # Purpose
+ The converter acts as a boundary layer between the Linux input subsystem and
+ BlazeRemap's core logic, allowing the rest of the application to work with
+ clean, domain-specific types regardless of the underlying platform.
 
-   # Event Mapping
-   | evdev EventType      | BlazeRemap EventType | Description          |
-   |---------------------|----------------------|-----------------------|
-   | `KEY`               | `Button`             | Controller buttons    |
-   | `ABSOLUTE`          | `Axis`               | Analog sticks/triggers|
-   | `SYNCHRONIZATION`   | `Sync`               | Frame boundaries      |
-   | `SWITCH`            | `DPad`               | Directional pad       |
-   | Others              | `None`               | Filtered out          |
+ # Event Mapping
+ | evdev EventType      | BlazeRemap EventType | Description          |
+ |---------------------|----------------------|-----------------------|
+ | `KEY`               | `Button`             | Controller buttons    |
+ | `ABSOLUTE`          | `Axis`               | Analog sticks/triggers|
+ | `SYNCHRONIZATION`   | `Sync`               | Frame boundaries      |
+ | `SWITCH`            | `DPad`               | Directional pad       |
+ | Others              | `None`               | Filtered out          |
 
-   # Timestamp Handling
-   The converter discards evdev's kernel timestamp and captures a new [`Instant`]
-   when the event is converted. This timestamp represents when BlazeRemap's userspace
-   code received the event, which is the starting point for latency measurement.
+ # Timestamp Handling
+ The converter discards evdev's kernel timestamp and captures a new [`Instant`]
+ when the event is converted. This timestamp represents when BlazeRemap's userspace
+ code received the event, which is the starting point for latency measurement.
 
-   # Note
-   Unsupported evdev event types (LED, SOUND, etc.) are filtered out and return
-   `None`, as they are not relevant for controller input remapping.
+ # Note
+ Unsupported evdev event types (LED, SOUND, etc.) are filtered out and return
+ `None`, as they are not relevant for controller input remapping.
 */
-use crate::event::{EventType, InputEvent};
+
+use crate::event::{AxisCode, ButtonCode, InputEvent, system_time_to_instant};
 
 pub fn evdev_to_input(ev: evdev::InputEvent) -> Option<InputEvent> {
-    let event_type = match ev.event_type() {
-        evdev::EventType::KEY => EventType::Button,
-        evdev::EventType::ABSOLUTE => EventType::Axis,
-        evdev::EventType::SYNCHRONIZATION => EventType::Sync,
-        evdev::EventType::SWITCH => EventType::DPad,
-        _ => return None,
-    };
+    //  Convert kernel's SystemTime to Instant (preserves timing)
+    let timestamp = system_time_to_instant(ev.timestamp());
+    println!("evdev_to_input timestamp: {:?}", timestamp);
 
-    let timestamp = std::time::Instant::now();
+    match ev.destructure() {
+        evdev::EventSummary::Key(_, key_code, _value) => {
+            let button_code = key_to_button_code(key_code);
+            let pressed = _value > 0;
+            Some(InputEvent::Button { code: button_code, pressed, timestamp })
+        }
+        evdev::EventSummary::AbsoluteAxis(_, axis_code, value) => {
+            let axis_code = axis_to_axis_code(axis_code);
+            Some(InputEvent::Axis { code: axis_code, value, timestamp })
+        }
+        evdev::EventSummary::Switch(_, _switch_code, _value) => {
+            // DPad events are typically handled as axes (ABS_HAT0X/Y) rather than switches
+            // For now, we'll skip switch events as they're not commonly used for gamepads
+            None
+        }
+        evdev::EventSummary::Synchronization(_, _, _) => Some(InputEvent::Sync { timestamp }),
+        _ => None,
+    }
+}
 
-    Some(InputEvent { event_type, code: ev.code(), value: ev.value(), timestamp })
+fn key_to_button_code(key: evdev::KeyCode) -> ButtonCode {
+    match key {
+        evdev::KeyCode::BTN_SOUTH => ButtonCode::South,
+        evdev::KeyCode::BTN_EAST => ButtonCode::East,
+        evdev::KeyCode::BTN_NORTH => ButtonCode::North,
+        evdev::KeyCode::BTN_WEST => ButtonCode::West,
+        evdev::KeyCode::BTN_TL => ButtonCode::LeftShoulder,
+        evdev::KeyCode::BTN_TR => ButtonCode::RightShoulder,
+        evdev::KeyCode::BTN_TL2 => ButtonCode::LeftTrigger,
+        evdev::KeyCode::BTN_TR2 => ButtonCode::RightTrigger,
+        evdev::KeyCode::BTN_SELECT => ButtonCode::Select,
+        evdev::KeyCode::BTN_START => ButtonCode::Start,
+        evdev::KeyCode::BTN_MODE => ButtonCode::Mode,
+        evdev::KeyCode::BTN_THUMBL => ButtonCode::LeftStick,
+        evdev::KeyCode::BTN_THUMBR => ButtonCode::RightStick,
+        evdev::KeyCode::BTN_TRIGGER_HAPPY1 => ButtonCode::Paddle1,
+        evdev::KeyCode::BTN_TRIGGER_HAPPY2 => ButtonCode::Paddle2,
+        evdev::KeyCode::BTN_TRIGGER_HAPPY3 => ButtonCode::Paddle3,
+        evdev::KeyCode::BTN_TRIGGER_HAPPY4 => ButtonCode::Paddle4,
+        _ => ButtonCode::Unknown,
+    }
+}
+
+fn axis_to_axis_code(axis: evdev::AbsoluteAxisCode) -> AxisCode {
+    match axis {
+        evdev::AbsoluteAxisCode::ABS_X => AxisCode::LeftX,
+        evdev::AbsoluteAxisCode::ABS_Y => AxisCode::LeftY,
+        evdev::AbsoluteAxisCode::ABS_RX => AxisCode::RightX,
+        evdev::AbsoluteAxisCode::ABS_RY => AxisCode::RightY,
+        evdev::AbsoluteAxisCode::ABS_Z => AxisCode::LeftTrigger,
+        evdev::AbsoluteAxisCode::ABS_RZ => AxisCode::RightTrigger,
+        evdev::AbsoluteAxisCode::ABS_HAT0X => AxisCode::DPadX,
+        evdev::AbsoluteAxisCode::ABS_HAT0Y => AxisCode::DPadY,
+        _ => AxisCode::Unknown,
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use evdev::{EventType as EvdevEventType, InputEvent as EvdevEvent};
+    use evdev::InputEvent as EvdevEvent;
     use std::time::Duration;
 
     #[test]
     fn test_evdev_key_to_button() {
-        let evdev_event = EvdevEvent::new(EvdevEventType::KEY, 304, 1);
+        let evdev_event = EvdevEvent::new(evdev::EventType::KEY.0, 0x130, 1);
         let result = evdev_to_input(evdev_event);
         assert!(result.is_some());
         let event = result.unwrap();
-        assert_eq!(event.event_type, EventType::Button);
-        assert_eq!(event.code, 304);
-        assert_eq!(event.value, 1);
+        assert!(matches!(event, InputEvent::Button { code: ButtonCode::South, pressed: true, .. }));
     }
 
     #[test]
     fn test_evdev_abs_to_axis() {
-        let evdev_event = EvdevEvent::new(EvdevEventType::ABSOLUTE, 0, 15234);
+        use crate::event::init_time_anchor;
+        init_time_anchor();
+
+        let evdev_event = EvdevEvent::new_now(evdev::EventType::ABSOLUTE.0, 0x00, 15234);
         let result = evdev_to_input(evdev_event);
         assert!(result.is_some());
         let event = result.unwrap();
-        assert_eq!(event.event_type, EventType::Axis);
-        assert_eq!(event.code, 0);
-        assert_eq!(event.value, 15234);
+        assert!(matches!(event, InputEvent::Axis { code: AxisCode::LeftX, value: 15234, .. }));
     }
 
     #[test]
     fn test_evdev_sync_returns_sync() {
-        let evdev_event = EvdevEvent::new(EvdevEventType::SYNCHRONIZATION, 0, 0);
+        let evdev_event = EvdevEvent::new(evdev::EventType::SYNCHRONIZATION.0, 0, 0);
         let result = evdev_to_input(evdev_event);
         assert!(result.is_some());
         let event = result.unwrap();
-        assert_eq!(event.event_type, EventType::Sync);
-    }
-
-    #[test]
-    fn test_evdev_switch_to_dpad() {
-        let evdev_event = EvdevEvent::new(EvdevEventType::SWITCH, 0, 1);
-        let result = evdev_to_input(evdev_event);
-        assert!(result.is_some());
-        let event = result.unwrap();
-        assert_eq!(event.event_type, EventType::DPad);
+        assert!(matches!(event, InputEvent::Sync { .. }));
     }
 
     #[test]
     fn test_unsupported_event_type_returns_none() {
-        let evdev_event = EvdevEvent::new(EvdevEventType::LED, 0, 1);
+        let evdev_event = EvdevEvent::new(evdev::EventType::LED.0, 0, 1);
         let result = evdev_to_input(evdev_event);
         assert!(result.is_none());
     }
 
     #[test]
     fn test_timestamp_is_recent() {
-        let before = std::time::Instant::now();
-        let evdev_event = EvdevEvent::new(EvdevEventType::KEY, 304, 1);
-        let event = evdev_to_input(evdev_event).unwrap();
-        let after = std::time::Instant::now();
+        use crate::event::init_time_anchor;
 
-        // Timestamp should be captured during conversion
-        assert!(event.timestamp >= before);
-        assert!(event.timestamp <= after);
+        init_time_anchor();
+
+        let evdev_event = EvdevEvent::new_now(evdev::EventType::KEY.0, 0x130, 1);
+        let event = evdev_to_input(evdev_event).unwrap();
+
+        let age = event.timestamp().elapsed();
+        assert!(age < Duration::from_secs(1), "Event timestamp is too old: {:?}", age);
     }
 
     #[test]
     fn test_timestamps_are_monotonic() {
+        use crate::event::init_time_anchor;
+
+        init_time_anchor();
+
         // Create two events in sequence
-        let event1 = evdev_to_input(EvdevEvent::new(EvdevEventType::KEY, 304, 1)).unwrap();
+        let event1 =
+            evdev_to_input(EvdevEvent::new_now(evdev::EventType::KEY.0, 0x130, 1)).unwrap();
 
         // Small delay to ensure time advances
-        std::thread::sleep(Duration::from_micros(100));
+        std::thread::sleep(Duration::from_millis(10));
 
-        let event2 = evdev_to_input(EvdevEvent::new(EvdevEventType::KEY, 305, 1)).unwrap();
+        let event2 =
+            evdev_to_input(EvdevEvent::new_now(evdev::EventType::KEY.0, 0x131, 1)).unwrap();
 
-        // Second timestamp should be >= first (monotonic property)
-        assert!(event2.timestamp >= event1.timestamp);
+        assert!(
+            event2.timestamp() >= event1.timestamp(),
+            "Timestamps not monotonic: event2 {:?} < event1 {:?}",
+            event2.timestamp(),
+            event1.timestamp()
+        );
     }
 
     #[test]
     fn test_elapsed_is_non_negative() {
-        let evdev_event = EvdevEvent::new(EvdevEventType::KEY, 304, 1);
+        let evdev_event = EvdevEvent::new(evdev::EventType::KEY.0, 0x130, 1);
         let event = evdev_to_input(evdev_event).unwrap();
 
         // Elapsed time is always >= 0 (Instant is monotonic)
-        assert!(event.timestamp.elapsed() >= Duration::ZERO);
+        assert!(event.timestamp().elapsed() >= Duration::ZERO);
+    }
+
+    #[test]
+    fn test_duration_preservation() {
+        use crate::event::init_time_anchor;
+
+        init_time_anchor();
+
+        let event1 =
+            evdev_to_input(EvdevEvent::new_now(evdev::EventType::KEY.0, 0x130, 1)).unwrap();
+
+        // Known delay
+        std::thread::sleep(Duration::from_millis(50));
+
+        let event2 =
+            evdev_to_input(EvdevEvent::new_now(evdev::EventType::KEY.0, 0x131, 1)).unwrap();
+
+        // ✅ Delta should be approximately 50ms
+        let delta = event2.timestamp().duration_since(event1.timestamp());
+        assert!(delta >= Duration::from_millis(50), "Delta too small: {:?}", delta);
+        assert!(delta < Duration::from_millis(100), "Delta too large: {:?}", delta);
+    }
+
+    #[test]
+    fn test_all_button_code_mappings() {
+        // Test a few key button mappings to ensure they work
+        assert_eq!(key_to_button_code(evdev::KeyCode::BTN_SOUTH), ButtonCode::South);
+        assert_eq!(key_to_button_code(evdev::KeyCode::BTN_EAST), ButtonCode::East);
+        assert_eq!(key_to_button_code(evdev::KeyCode::BTN_NORTH), ButtonCode::North);
+        assert_eq!(key_to_button_code(evdev::KeyCode::BTN_WEST), ButtonCode::West);
+        assert_eq!(key_to_button_code(evdev::KeyCode::BTN_START), ButtonCode::Start);
+        assert_eq!(key_to_button_code(evdev::KeyCode::BTN_SELECT), ButtonCode::Select);
+        assert_eq!(key_to_button_code(evdev::KeyCode::BTN_MODE), ButtonCode::Mode);
+    }
+
+    #[test]
+    fn test_all_axis_code_mappings() {
+        // Test all axis mappings
+        assert_eq!(axis_to_axis_code(evdev::AbsoluteAxisCode::ABS_X), AxisCode::LeftX);
+        assert_eq!(axis_to_axis_code(evdev::AbsoluteAxisCode::ABS_Y), AxisCode::LeftY);
+        assert_eq!(axis_to_axis_code(evdev::AbsoluteAxisCode::ABS_RX), AxisCode::RightX);
+        assert_eq!(axis_to_axis_code(evdev::AbsoluteAxisCode::ABS_RY), AxisCode::RightY);
+        assert_eq!(axis_to_axis_code(evdev::AbsoluteAxisCode::ABS_Z), AxisCode::LeftTrigger);
+        assert_eq!(axis_to_axis_code(evdev::AbsoluteAxisCode::ABS_RZ), AxisCode::RightTrigger);
+        assert_eq!(axis_to_axis_code(evdev::AbsoluteAxisCode::ABS_HAT0X), AxisCode::DPadX);
+        assert_eq!(axis_to_axis_code(evdev::AbsoluteAxisCode::ABS_HAT0Y), AxisCode::DPadY);
+    }
+
+    #[test]
+    fn test_unknown_codes_map_to_unknown() {
+        // Test that unknown codes map to Unknown variants
+        // We can't easily create unknown enum variants, so we'll test
+        // that our mapping functions are total (cover all expected cases)
+        // This test passes as long as no panics occur for any input
+        let _result1 = key_to_button_code(evdev::KeyCode::KEY_A);
+        let _result2 = axis_to_axis_code(evdev::AbsoluteAxisCode::ABS_X);
+        // The functions should return ButtonCode::Unknown or AxisCode::Unknown for unmapped codes
     }
 }

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -3,6 +3,7 @@ mod converter;
 mod device_manager;
 mod errors;
 
+pub use controller::LinuxController;
 pub use converter::evdev_to_input;
 pub use device_manager::LinuxDeviceManager;
 pub use errors::LinuxError;


### PR DESCRIPTION
- Created LinuxController struct in src/platform/linux/controller.rs that implements the Controller trait
- Added platform-agnostic enums to represent the controller events
- Add blocking event loop to poll controller's events
- Implemented Deadzone logic for Sony's DualShock4 analog sticks as it records idle analog events (slightly off from exact center points)
- Refactored the InputEvent from a struct to a proper enum that enforces type safety at compile time
- Implemented global anchor time and SystemTime -> Instant mapping to preserve event order/monotonicity
- Switched evdev conversion to EventSummary-based path (evdev 0.13.2) with relative timing preserved
- Graceful disconnect via raw_os_error() ENODEV (19)
- Removed serde usage in Phase 2 (Cargo.toml and derives adjusted)
- Added tests for event timing, anchor usage, and disconnect handling