### PR TITLE
feat: Keyboard test wiring and platform integration [#6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "predicates",
  "thiserror",
  "toml",
+ "tracing",
  "tracing-subscriber",
 ]
 
@@ -686,7 +687,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,8 +33,7 @@ evdev = "0.13.2"          # Main evdev library
 
 # Logging
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-
-
+tracing = "0.1.44"
 
 # Threading utilities
 crossbeam = "0.8.4"     # For channels

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# scripts/test_integration.sh
+
+set -e
+
+echo "================================================"
+echo "BlazeRemap Virtual Keyboard Integration Tests"
+echo "================================================"
+echo ""
+
+# Check for root
+if [ "$EUID" -ne 0 ]; then
+    echo "❌ Error: Integration tests require root access"
+    echo "   Run with: sudo ./scripts/test_integration.sh"
+    exit 1
+fi
+
+# Check for /dev/uinput
+if [ ! -e /dev/uinput ]; then
+    echo "❌ Error: /dev/uinput not found"
+    echo "   Run: sudo modprobe uinput"
+    exit 1
+fi
+
+echo "✓ Running as root"
+echo "✓ /dev/uinput available"
+echo ""
+
+# Run tests
+echo "Running integration tests..."
+cargo test --test virtual_keyboard_integration_test -- --ignored --nocapture
+
+echo ""
+echo "================================================"
+echo "✓ All integration tests passed!"
+echo "================================================"

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 // CLI module - command definitions and handling
 mod detect;
 mod read;
+mod test_keyboard;
 
 use clap::Command;
 
@@ -14,6 +15,7 @@ pub fn build_cli() -> Command {
         .arg_required_else_help(true)
         .subcommand(detect::command())
         .subcommand(read::command())
+        .subcommand(test_keyboard::command())
 }
 
 /// Execute the CLI and handle the result
@@ -23,6 +25,7 @@ pub fn execute() -> anyhow::Result<()> {
     match matches.subcommand() {
         Some(("detect", sub_matches)) => detect::handle(sub_matches),
         Some(("read", sub_matches)) => read::handle(sub_matches),
+        Some(("test-keyboard", sub_matches)) => test_keyboard::handle(sub_matches),
         _ => unreachable!("Subcommand required"),
     }
 }

--- a/src/cli/test_keyboard.rs
+++ b/src/cli/test_keyboard.rs
@@ -1,0 +1,41 @@
+use crate::output::keyboard::VirtualKeyboard;
+// src/cli/test_keyboard.rs
+use crate::platform::linux::LinuxVirtualKeyboard;
+use anyhow::Result;
+use clap::Command;
+use evdev::KeyCode;
+use std::thread;
+use std::time::Duration;
+
+pub fn command() -> Command {
+    Command::new("test-keyboard").about("Test virtual keyboard by emitting space key every second")
+}
+
+pub fn handle(_matches: &clap::ArgMatches) -> Result<()> {
+    println!("Creating virtual keyboard...");
+    let mut keyboard = LinuxVirtualKeyboard::new("BlazeRemap Test Keyboard")?;
+
+    // Try to show sysfs path
+    match keyboard.sys_path() {
+        Ok(path) => {
+            println!("Virtual device sysfs path: {:?}", path);
+            println!("Device node will be in /dev/input/ (use 'evtest' to find it)");
+        }
+        Err(e) => {
+            println!("Note: Could not get sysfs path: {}", e);
+        }
+    }
+
+    println!("\nEmitting space key every second...");
+    println!("Open a text editor to see the output.");
+    println!("Press Ctrl+C to stop.\n");
+
+    // Emit space key in a loop
+    for i in 1.. {
+        keyboard.tap_key(KeyCode::KEY_SPACE.code())?;
+        println!("[{}] Space key tapped", i);
+        thread::sleep(Duration::from_secs(1));
+    }
+
+    Ok(())
+}

--- a/src/output/keyboard.rs
+++ b/src/output/keyboard.rs
@@ -1,0 +1,13 @@
+use anyhow::Result;
+
+/// Domain trait: abstract virtual keyboard operations
+pub trait VirtualKeyboard {
+    /// Press a key by its code
+    fn press_key(&mut self, code: u16) -> Result<()>;
+    /// Release a key by its code
+    fn release_key(&mut self, code: u16) -> Result<()>;
+    /// Tap a key (press then release)
+    fn tap_key(&mut self, code: u16) -> Result<()>;
+    /// Get sysfs path (for debugging)
+    fn sys_path(&mut self) -> Result<std::path::PathBuf>;
+}

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,1 +1,1 @@
-
+pub mod keyboard;

--- a/src/platform/linux/keyboard.rs
+++ b/src/platform/linux/keyboard.rs
@@ -1,0 +1,88 @@
+// Task 6: Virtual Keyboard Module (domain abstraction separation)
+use anyhow::{Context, Result};
+use evdev::{AttributeSet, EventType, InputEvent as EvdevEvent, KeyCode, uinput::VirtualDevice};
+use std::path::PathBuf;
+
+// Domain trait import
+use crate::output::keyboard::VirtualKeyboard;
+
+/// Concrete virtual keyboard backed by /dev/uinput
+pub struct LinuxVirtualKeyboard {
+    device: VirtualDevice,
+}
+
+impl LinuxVirtualKeyboard {
+    /// Create a new virtual keyboard device
+    pub fn new(name: &str) -> Result<Self> {
+        // Build a key set including all common keyboard keys
+        let mut keys = AttributeSet::<KeyCode>::new();
+        for code in KeyCode::KEY_ESC.code()..=KeyCode::KEY_MICMUTE.code() {
+            keys.insert(KeyCode::new(code));
+        }
+
+        // Build virtual device
+        let device = VirtualDevice::builder()?
+            .name(name)
+            .with_keys(&keys)?
+            .build()
+            .context("Failed to create virtual keyboard")?;
+
+        tracing::info!("Virtual keyboard created: {}", name);
+
+        Ok(Self { device })
+    }
+
+    // Low-level helpers operating on key codes
+    fn press_key_code(&mut self, code: u16) -> Result<()> {
+        let key = KeyCode::new(code);
+        self.device.emit(&[
+            EvdevEvent::new(EventType::KEY.0, key.code(), 1),
+            EvdevEvent::new(EventType::SYNCHRONIZATION.0, 0, 0),
+        ])?;
+        Ok(())
+    }
+
+    fn release_key_code(&mut self, code: u16) -> Result<()> {
+        let key = KeyCode::new(code);
+        self.device.emit(&[
+            EvdevEvent::new(EventType::KEY.0, key.code(), 0),
+            EvdevEvent::new(EventType::SYNCHRONIZATION.0, 0, 0),
+        ])?;
+        Ok(())
+    }
+
+    fn tap_key_code(&mut self, code: u16) -> Result<()> {
+        self.press_key_code(code)?;
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        self.release_key_code(code)?;
+        Ok(())
+    }
+
+    pub fn sys_path(&mut self) -> Result<PathBuf> {
+        self.device.get_syspath().context("Failed to get device sysfs path")
+    }
+}
+
+impl Drop for LinuxVirtualKeyboard {
+    fn drop(&mut self) {
+        // Cleanup handled by UInputDevice drop
+    }
+}
+
+// Implement the domain trait for this concrete type
+impl VirtualKeyboard for LinuxVirtualKeyboard {
+    fn press_key(&mut self, code: u16) -> Result<()> {
+        self.press_key_code(code)
+    }
+
+    fn release_key(&mut self, code: u16) -> Result<()> {
+        self.release_key_code(code)
+    }
+
+    fn tap_key(&mut self, code: u16) -> Result<()> {
+        self.tap_key_code(code)
+    }
+    fn sys_path(&mut self) -> Result<std::path::PathBuf> {
+        self.sys_path()
+    }
+}

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -2,8 +2,10 @@ mod controller;
 mod converter;
 mod device_manager;
 mod errors;
+mod keyboard;
 
 pub use controller::LinuxController;
 pub use converter::evdev_to_input;
 pub use device_manager::LinuxDeviceManager;
 pub use errors::LinuxError;
+pub use keyboard::LinuxVirtualKeyboard;

--- a/tests/virtual_keyboard_integration_test.rs
+++ b/tests/virtual_keyboard_integration_test.rs
@@ -1,0 +1,150 @@
+// tests/virtual_keyboard_integration.rs
+
+use blazeremap::output::keyboard::VirtualKeyboard;
+use blazeremap::platform::linux::LinuxVirtualKeyboard;
+use evdev::{Device, KeyCode};
+use std::thread;
+use std::time::Duration;
+
+/// Helper function to find a device by name in /dev/input
+fn find_device_by_name(name: &str) -> Option<String> {
+    for entry in std::fs::read_dir("/dev/input").ok()? {
+        let entry = entry.ok()?;
+        let path = entry.path();
+
+        if path.to_str()?.contains("event") {
+            if let Ok(device) = Device::open(&path) {
+                if let Some(device_name) = device.name() {
+                    if device_name.contains(name) {
+                        return Some(path.to_string_lossy().to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+#[test]
+#[ignore] // Only run with: cargo test -- --ignored --include-ignored
+fn test_virtual_keyboard_creation() {
+    // This test requires root/uinput permissions
+    let result = LinuxVirtualKeyboard::new("BlazeRemap Integration Test");
+
+    assert!(result.is_ok(), "Failed to create virtual keyboard: {:?}", result.err());
+
+    // Give udev time to register the device
+    thread::sleep(Duration::from_millis(100));
+
+    // Verify device appears in /dev/input
+    let device_path = find_device_by_name("BlazeRemap Integration Test");
+    assert!(device_path.is_some(), "Virtual keyboard not found in /dev/input");
+
+    println!("✓ Virtual keyboard created at: {:?}", device_path);
+}
+
+#[test]
+#[ignore]
+fn test_virtual_keyboard_key_press_release() {
+    let mut keyboard = LinuxVirtualKeyboard::new("BlazeRemap Key Test")
+        .expect("Failed to create virtual keyboard");
+
+    // Test press
+    let result = keyboard.press_key(KeyCode::KEY_A.code());
+    assert!(result.is_ok(), "Failed to press key: {:?}", result.err());
+
+    thread::sleep(Duration::from_millis(50));
+
+    // Test release
+    let result = keyboard.release_key(KeyCode::KEY_A.code());
+    assert!(result.is_ok(), "Failed to release key: {:?}", result.err());
+
+    println!("✓ Key press/release successful");
+}
+
+#[test]
+#[ignore]
+fn test_virtual_keyboard_tap() {
+    let mut keyboard = LinuxVirtualKeyboard::new("BlazeRemap Tap Test")
+        .expect("Failed to create virtual keyboard");
+
+    // Test tap (press + release)
+    let result = keyboard.tap_key(KeyCode::KEY_SPACE.code());
+    assert!(result.is_ok(), "Failed to tap key: {:?}", result.err());
+
+    println!("✓ Key tap successful");
+}
+
+#[test]
+#[ignore]
+fn test_virtual_keyboard_multiple_keys() {
+    let mut keyboard = LinuxVirtualKeyboard::new("BlazeRemap Multi Key Test")
+        .expect("Failed to create virtual keyboard");
+
+    let keys = [KeyCode::KEY_A, KeyCode::KEY_B, KeyCode::KEY_C, KeyCode::KEY_SPACE];
+
+    for key in &keys {
+        let result = keyboard.tap_key(key.code());
+        assert!(result.is_ok(), "Failed to tap {:?}: {:?}", key, result.err());
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    println!("✓ Multiple key taps successful");
+}
+
+#[test]
+#[ignore]
+fn test_virtual_keyboard_cleanup() {
+    let device_name = "BlazeRemap Cleanup Test";
+
+    // Create keyboard
+    let keyboard =
+        LinuxVirtualKeyboard::new(device_name).expect("Failed to create virtual keyboard");
+
+    thread::sleep(Duration::from_millis(100));
+
+    // Verify it exists
+    let device_path = find_device_by_name(device_name);
+    assert!(device_path.is_some(), "Device not found after creation");
+
+    // Drop the keyboard (cleanup)
+    drop(keyboard);
+
+    // Give kernel time to remove device
+    thread::sleep(Duration::from_millis(200));
+
+    // Verify it's gone
+    let device_path_after = find_device_by_name(device_name);
+    assert!(device_path_after.is_none(), "Device still exists after cleanup");
+
+    println!("✓ Virtual keyboard cleanup successful");
+}
+
+#[test]
+#[ignore]
+fn test_virtual_keyboard_sys_path() {
+    let mut keyboard = LinuxVirtualKeyboard::new("BlazeRemap SysPath Test")
+        .expect("Failed to create virtual keyboard");
+
+    let sys_path = keyboard.sys_path();
+    assert!(sys_path.is_ok(), "Failed to get sys_path: {:?}", sys_path.err());
+
+    let path = sys_path.unwrap();
+    assert!(path.starts_with("/sys/devices/virtual/input"));
+
+    println!("✓ Sysfs path: {:?}", path);
+}
+
+#[test]
+#[ignore]
+fn test_virtual_keyboard_rapid_events() {
+    let mut keyboard = LinuxVirtualKeyboard::new("BlazeRemap Rapid Test")
+        .expect("Failed to create virtual keyboard");
+
+    // Simulate rapid button mashing (100 taps)
+    for _ in 0..100 {
+        keyboard.tap_key(KeyCode::KEY_SPACE.code()).expect("Failed during rapid tap test");
+    }
+
+    println!("✓ Rapid event test successful (100 taps)");
+}


### PR DESCRIPTION
- Add CLI subcommand: test-keyboard
- Introduce keyboard module in output and export LinuxVirtualKeyboard in linux platform
- Wire up module declarations for keyboard integration
- Update dependencies: tracing and tracing-attributes in Cargo.toml/Cargo.lock
- Reflect changes in CLI and platform wiring