### PR TITLE
feat: update documentations [#11]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,4 @@
 *.deb
 *.rpm
 *.tar.gz
-
-docs/
-.rules
+# .rules

--- a/.rules
+++ b/.rules
@@ -1,0 +1,27 @@
+## Role and Purpose
+You are a senior software architect and engineer assisting in the development of a input remapper native application. Your primary function is to provide guidance, code snippets, and explanations related to this project.
+
+## General Behavior
+- Do not generate code or code snippets unless you're explicitly asked
+- Prioritize clarity and efficiency in your responses.
+- When providing code, use appropriate syntax highlighting.
+- If unsure about a specific requirement, ask for clarification before proceeding.
+
+## Code Style and Best Practices
+- Follow idiomatic Rust, Domain-Driven Design and clean code practice for the project's architecture and code.
+- Implement proper error handling and input validation.
+- Write clean, modular, and well-commented code.
+- Adhere to Rust best practices for concurrency, context, and error handling.
+
+## Output Preferences
+- When providing code snippets, include brief explanations of the code's functionality.
+- For complex features, break down the implementation into step-by-step instructions.
+- Suggest testing strategies for critical components.
+
+## Limitations
+- Do not provide complete application code; focus on specific components or functions as requested.
+- Avoid discussing deployment strategies or practices unless explicitly asked.
+
+## Additional Notes
+- Be prepared to explain concepts related to state management, API integration, and database/storage schema design.
+- Offer suggestions for performance optimization and scalability when relevant.

--- a/README.md
+++ b/README.md
@@ -1,130 +1,92 @@
 # BlazeRemap
 
-Linux keyboard-to-gamepad remapping software.
+BlazeRemap is a high-performance Linux input remapper designed to translate physical gamepad signals into virtual keyboard events. By operating at the kernel level via `evdev` and `uinput`, it allows you to use any controller in games or applications that only support keyboard input, with near-zero latency.
 
-## Features
+## Current Features
 
-- ✅ Gamepad detection (Xbox, PlayStation, generic gamepads)
-- ✅ Vendor identification (Microsoft, Sony, etc.)
-- ✅ Capability detection (Force Feedback, Elite Paddles)
-- ✅ Command-line interface
-- ⏳ Button remapping (Phase 2)
-- ⏳ Profile management (Phase 2)
+- **Hexagonal Architecture**: Core remapping logic is decoupled from Linux-specific APIs, ensuring high testability and reliability.
+- **Kernel-Level Emulation**: Uses `uinput` to create a virtual keyboard that is recognized globally across the OS (TTY, X11, and Wayland).
+- **Stateful Axis Mapping**: Intelligently handles D-pad and analog movements to simulate binary key presses and releases without "stuck keys."
+- **Low Latency**: Synchronous, blocking event loop designed for gaming, featuring microsecond-precision latency tracking.
+- **Device Discovery**: Automatic detection of connected gamepads with hardware identification (Vendor/Product IDs).
+- **TOML Profiles**: Simple, human-readable configuration for button and axis mappings.
 
-## Requirements
-
-- Linux kernel 5.15+
-- User in `input` group
-- Rust 1.70+ (for building)
-
-## Installation
-
-### From Source
-```bash
-# Clone the repository
-git clone https://github.com/rohmanhakim/blazeremap
-cd blazeremap
-
-# Build
-cargo build --release
-
-# Install (optional)
-cargo install --path .
-```
-
-### Setup Permissions
-```bash
-# Add user to input group
-sudo usermod -a -G input $USER
-
-# Create udev rule for uinput
-echo 'KERNEL=="uinput", MODE="0660", GROUP="uinput"' | \
-  sudo tee /etc/udev/rules.d/99-blazeremap.rules
-
-# Load uinput module
-sudo modprobe uinput
-echo "uinput" | sudo tee -a /etc/modules
-
-# Log out and back in for group changes to take effect
-```
-
-## Usage
+## CLI Usage & Examples
 
 ### Detect Gamepads
+List all compatible controllers connected to your system.
 ```bash
 blazeremap detect
-
-# With verbose output
-blazeremap detect --verbose
 ```
-
-### Example Output
-```
+**Output Example:**
+```text
 Detecting gamepads...
-
-Found 28 input devices total
-Found gamepad: Wireless Controller
-✓ Detected: Wireless Controller (DualShock 4) - [ForceFeedback]
-Found 1 gamepads (0 errors)
 
 Found 1 gamepad(s):
 
-[0] Wireless Controller (/dev/input/event25)
- ├─ Type: DualShock 4
+[0] Xbox Wireless Controller (/dev/input/event3)
+ ├─ Type: Xbox One
  ├─ Vendor:
- │  ├─ ID: 054C
- │  └─ Name: Sony
- ├─ Product ID: 09CC
+ │  ├─ ID: 045E
+ │  └─ Name: Microsoft
+ ├─ Product ID: 02EA
  └─ Capabilities:
     └─ Force Feedback
 ```
 
-## Development
-
-### Running Tests
+### Run Remapper
+Start the remapping daemon using either auto-detection or a specific device path.
 ```bash
-# Unit tests
-cargo test --lib
+blazeremap run --device /dev/input/event3
+```
+**Output Example:**
+```text
+Opening device: /dev/input/event3
+Loading hardcoded mappings...
+Creating virtual keyboard...
 
-# Integration tests
-cargo test --test types_test
+BlazeRemap is now running!
+Mappings:
+  D-pad button → Arrow
+  South button → S
+  West button → A
+  East button → D
 
-# Hardware tests (requires gamepad connected)
-cargo test --test hardware_test -- --ignored --nocapture
-
-# All tests
-./test_hardware.sh
+[INFO] Stats: 100 events | avg: 42µs (0.04ms) | min: 12µs | max: 156µs
 ```
 
-### Project Structure
+### Debug Events
+Monitor raw input events from a device to verify button codes.
+```bash
+blazeremap read /dev/input/event3
 ```
-src/
-├── main.rs              # Binary entry point
-├── lib.rs               # Library root
-├── app.rs               # App composition
-├── cli/                 # CLI commands
-│   ├── mod.rs
-│   └── detect.rs
-├── device/              # Device abstractions
-│   ├── mod.rs
-│   ├── manager.rs
-│   └── gamepad/
-└── platform/            # Platform implementations
-    ├── mod.rs
-    └── linux/
-        ├── mod.rs
-        ├── errors.rs
-        ├── gamepad.rs
-        └── device_manager.rs
+**Output Example:**
+```text
+[   0.00000ms][Δ        0µs] Button(South, Pressed)
+[  45.12000ms][Δ    45120µs] Button(South, Released)
 ```
 
-## Supported Gamepads
+### Test Virtual Keyboard
+Verify that the `uinput` module is working correctly by emitting a space key every second.
+```bash
+blazeremap test-keyboard
+```
 
-| Gamepad | Detection | Capabilities |
-|------------|-----------|--------------|
-| Xbox One | ✅ | Force Feedback |
-| Xbox Series X/S | ✅ | Force Feedback |
-| Xbox Elite | ✅ | Force Feedback, Paddles |
-| DualShock 4 | ✅ | Force Feedback |
-| DualSense (PS5) | ✅ | Force Feedback |
-| Generic HID | ✅ | Varies |
+## Planned Features
+
+The following features are partially implemented in the codebase (structs/detection logic) or are on the immediate roadmap:
+
+- [ ] **Force Feedback (Rumble) Support**: Logic for detecting rumble capabilities exists; wiring the output feedback loop is planned.
+- [ ] **Xbox Elite Paddles**: Detection code for rear paddles is present; mapping support is pending.
+- [ ] **Custom Deadzones**: Ability to define per-axis deadzones in the TOML profile to combat stick drift.
+- [ ] **Macro Engine**: Support for simple sequences (e.g., mapping one button to `Alt+Tab`).
+- [ ] **Multi-Device Support**: Running one daemon instance to manage multiple controllers simultaneously.
+- [ ] **Cross-Platform Adapters**: While currently Linux-only, the architecture is designed to support Windows (RawInput) and macOS (IOKit) in the future.
+
+## Requirements
+
+- **Linux Kernel**: Requires `evdev` and `uinput` support.
+- **Permissions**: You must have read/write access to `/dev/input/*` and `/dev/uinput`. This is typically achieved by adding your user to the `input` and `uinput` groups:
+  ```bash
+  sudo usermod -aG input,uinput $USER
+  ```

--- a/docs/v0.1.0/phase-2/ARCHITECTURE.md
+++ b/docs/v0.1.0/phase-2/ARCHITECTURE.md
@@ -1,0 +1,38 @@
+# Architecture
+
+BlazeRemap is structured following a **Ports and Adapters (Hexagonal)** architecture. This design decouples the core remapping logic from the low-level Linux input subsystems, facilitating testability through mocks and ensuring that business rules remain isolated from I/O details.
+
+## Module Responsibilities
+
+- **Domain Core (`event`, `mapping`)**: Contains the "pure" logic and definitions. `event` defines the shared language (Input/Output events) and the orchestrating `EventLoop`. `mapping` contains the stateless engine that transforms signals based on configuration profiles.
+- **Port Interfaces (`input`, `output`)**: Defines the contracts (traits) for hardware interaction. These modules represent the "Ports" that the core uses to communicate with the outside world without knowing the implementation details.
+- **Platform Adapters (`platform`)**: Implements the port traits for specific environments. Currently, this houses the Linux-specific `evdev` (reader) and `uinput` (writer) logic.
+- **User Interface (`cli`)**: The driver layer that interprets user commands via `clap` and provides feedback.
+- **Composition Root (`app`, `main`)**: Responsible for bootstrapping the application, performing dependency injection by instantiating concrete platform adapters and passing them into the core event loop.
+
+## Ownership Boundaries
+
+- **The Event Loop**: Acts as the primary owner of the active session. It holds ownership of the `MappingEngine` and unique ownership (via `Box<dyn T>`) of the input and output device handles.
+- **The Input Manager**: Responsible for the lifecycle of device discovery. It produces owned `Gamepad` instances but does not retain ownership of them after they are opened.
+- **Mapping Engine**: Owns the state of the current transformation rules and the transient state of analog axes (to handle direction-change logic).
+
+## Dependency Direction Rules
+
+Dependencies flow **inward** toward the domain logic:
+1. `main` / `app` -> `cli`
+2. `cli` -> `platform`, `mapping`, `event`
+3. `platform` -> `input`, `output`, `event`
+4. `event` -> `mapping`
+5. `mapping` is a leaf dependency (depends only on internal types).
+
+## Allowed vs. Forbidden Couplings
+
+- **Allowed**: The `platform` module is allowed to depend on `evdev` and `nix` crates; it is the only module where hardware-specific types (like `evdev::Device`) should exist.
+- **Forbidden**: The `mapping` module must never depend on `platform` or any I/O-related crates. It must remain a pure function of `InputEvent -> Vec<OutputEvent>`.
+- **Forbidden**: Core domain types in `event` must not have dependencies on the `cli` or argument parsing logic.
+
+## Cross-Cutting Concerns
+
+- **Logging & Tracing**: Handled via the `tracing` crate. The `EventLoop` records latency metrics and event flows, which are collected by the `tracing-subscriber` initialized in `main`.
+- **Error Handling**: Uses `thiserror` for defining structured, recoverable errors in the library modules and `anyhow` for context-rich error reporting in the `cli` and `app` layers.
+- **Telemetry**: The `EventLoop` maintains internal counters for event frequency and processing latency, periodically logging performance statistics to help diagnose lag in the input pipeline.

--- a/docs/v0.1.0/phase-2/DECISIONS.md
+++ b/docs/v0.1.0/phase-2/DECISIONS.md
@@ -1,0 +1,73 @@
+# Architectural Decisions
+
+This document records the major architectural and technology decisions made during the development of BlazeRemap. These decisions shape the system's constraints, performance characteristics, and future extensibility.
+
+## Decision: Hexagonal Architecture (Ports and Adapters)
+Context:
+The application needs to interact with low-level Linux hardware APIs (`evdev`, `uinput`) while maintaining testable and maintainable business logic for remapping.
+
+Decision:
+We adopted a Hexagonal architecture where the core logic (`mapping`, `event`) is decoupled from the platform implementation (`platform/linux`). Communication happens through well-defined traits (`Gamepad`, `VirtualKeyboard`, `InputManager`).
+
+Alternatives considered:
+- **Monolithic design**: Mixing `evdev` calls directly with remapping logic. This was rejected because it makes unit testing impossible without real hardware.
+- **Platform-specific crates**: Creating separate crates for Linux. This was deemed overkill for the current project scale.
+
+Why this matters:
+It allows the core remapping logic to be tested using mocks (via `mockall`). It also provides a clear path for potential future support of other platforms or input protocols without rewriting the mapping engine.
+
+## Decision: Blocking Synchronous Event Loop
+Context:
+Low latency is the primary requirement for a gamepad remapper. Input lag must be minimized.
+
+Decision:
+The system uses a dedicated thread with a blocking `read_event` loop. The `evdev` file descriptor is polled synchronously to ensure the fastest possible path from hardware interrupt to virtual event synthesis.
+
+Alternatives considered:
+- **Async/Await (Tokio)**: While powerful, the overhead of an async runtime was considered unnecessary for a tool that typically manages a single device and a single event stream.
+- **Worker Thread Pool**: Spawning threads per event. Rejected due to context switching overhead and ordering concerns.
+
+Why this matters:
+Synchronous execution provides deterministic latency and simplifies the implementation of state-dependent mapping (like axis tracking) without worrying about complex concurrency primitives.
+
+## Decision: Linux Uinput for Virtual Input
+Context:
+The system must inject keystrokes into the OS as if they came from a physical keyboard.
+
+Decision:
+We use the Linux `uinput` kernel module via the `evdev` crate. This allows the creation of a virtual device that the kernel treats as a standard input source.
+
+Alternatives considered:
+- **X11/Wayland Synthetic Events**: These only work within the graphical session and are often blocked by security features in modern desktop environments (especially Wayland).
+- **Direct Library Injection**: Using `LD_PRELOAD` to intercept input calls. Too fragile and application-specific.
+
+Why this matters:
+`uinput` works at the kernel level, meaning BlazeRemap works across TTYs, X11, Wayland, and even inside most containers or virtual machines, providing "true" hardware emulation.
+
+## Decision: Internal State Tracking for Analog Axes
+Context:
+Gamepad D-pads and thumbsticks often report analog values or specific axis codes, while keyboards require discrete "Press" and "Release" signals.
+
+Decision:
+The `MappingEngine` maintains an internal `axis_states` map. It tracks the current position of axes to detect when they cross neutral thresholds or change directions, synthesizing the appropriate keyboard events dynamically.
+
+Alternatives considered:
+- **Stateless Mapping**: Simply sending a key press on every move. This results in "stuck" keys because the OS never receives a release signal.
+- **Time-based Polling**: Checking axis state at intervals. Rejected because it introduces unnecessary lag and jitter.
+
+Why this matters:
+This ensures "Release Symmetry"—the invariant that every synthesized key press is eventually followed by a release, preventing ghost inputs or stuck keys in games.
+
+## Decision: TOML for Profile Configuration
+Context:
+Users need a way to define and share custom controller mappings.
+
+Decision:
+Profiles are stored in TOML format. The `serde` and `toml` crates handle serialization and deserialization.
+
+Alternatives considered:
+- **JSON**: Easier for machines but harder for humans to edit manually without errors (lack of comments, strict syntax).
+- **YAML**: Human-readable but can be complex and has known security/performance edge cases in many parsers.
+
+Why this matters:
+TOML is the standard configuration language for the Rust ecosystem. It provides a clean, hierarchy-friendly syntax that is easy for users to edit in any text editor.

--- a/docs/v0.1.0/phase-2/DOMAIN_MODEL.md
+++ b/docs/v0.1.0/phase-2/DOMAIN_MODEL.md
@@ -1,0 +1,59 @@
+# Domain Model
+
+This document describes the core domain concepts, rules, and logic governing BlazeRemap. It focuses on the business logic of input remapping rather than the technical implementation details of Linux subsystems.
+
+## Terminology Mapping
+
+| Code Name | Business Meaning |
+| :--- | :--- |
+| **Gamepad** | A physical input device (controller) capable of generating button and axis signals. |
+| **Virtual Keyboard** | A software-defined input device that simulates a physical keyboard to the operating system. |
+| **Mapping** | A definition of a relationship between a specific gamepad signal and a keyboard response. |
+| **Profile** | A named configuration containing a set of Mappings and behavior settings (e.g., vibration intensity). |
+| **Input Event** | A normalized representation of a physical interaction (pressing a button, moving a stick). |
+| **Output Event** | A synthesized system instruction (pressing a key, releasing a key). |
+| **Axis** | An analog input providing a range of values (e.g., thumbsticks, triggers, D-pads). |
+| **Button** | A digital binary input (Pressed or Released). |
+| **Deadzone** | An "ignore zone" for analog values near neutral to prevent accidental or jittery input. |
+
+## Core Entities
+
+### 1. The Gamepad (Source)
+The Gamepad represents the user's physical hardware. It is characterized by its capabilities (how many buttons, does it have rumble, does it have paddles) and its current state. The system treats a Gamepad as a stream of raw signals that must be normalized into a standard dialect.
+
+### 2. The Virtual Keyboard (Sink)
+The Virtual Keyboard is the system's presence in the OS input stack. It exists to receive synthesized instructions and "act" as if a human pressed a physical key. It is agnostic of where the instructions come from.
+
+### 3. The Mapping Engine (Translator)
+The core logic engine. It maintains a lookup table of "Rules." When an Input Event arrives, the Engine determines which (if any) Output Events should be generated. It is responsible for translating analog "range" data into digital "binary" signals when mapping sticks to keys.
+
+### 4. The Profile (Configuration)
+A persistent set of user preferences. A Profile defines the "personality" of the remapper for a specific session or game.
+
+## State Machines & Lifecycle
+
+### Axis-to-Keyboard State Machine
+Unlike buttons, which have a 1:1 relationship with keys, analog axes require state tracking to simulate binary keys correctly.
+
+1.  **Neutral State**: The axis is centered. No output is active.
+2.  **Threshold Crossing (Active)**: When the axis moves beyond the deadzone into a defined direction (e.g., D-Pad Up), a **Press** event is emitted for the target key.
+3.  **Directional Swap**: If the axis moves directly from Positive to Negative (bypassing a prolonged Neutral state), the system must emit a **Release** for the old direction and a **Press** for the new direction in the same processing cycle.
+4.  **Threshold Crossing (Neutral)**: When the axis returns to the deadzone, a **Release** event is emitted for the active key.
+
+### Session Lifecycle
+1.  **Discovery**: The system scans for compatible hardware based on device capabilities (must have both buttons and axes).
+2.  **Acquisition**: The system opens a communication channel to the hardware.
+3.  **Transformation Loop**: A continuous cycle of `Read Physical -> Translate -> Write Virtual`.
+4.  **Termination**: Triggered by user exit or hardware disconnection. The system ensures the virtual device is destroyed to prevent ghost inputs.
+
+## Invariants & Business Rules
+
+### Invariants
+-   **Release Symmetry**: Every synthesized "Press" event must be followed by a "Release" event before that same key can be "Pressed" again. This prevents "stuck keys" in the operating system.
+-   **Input Normalization**: Regardless of whether a gamepad identifies a button as `0x130` or `0x131`, it is mapped to a domain-standard `ButtonCode` (e.g., `South`) before reaching the Mapping Engine.
+-   **Strict Ordering**: Events are processed FIFO (First-In, First-Out). The relative timing of inputs must be preserved to support rapid "chording" (holding multiple buttons).
+
+### Business Rules
+-   **Hardware Filtering**: Devices that identify as mice, keyboards, or audio devices are explicitly ignored during discovery, even if they report having buttons/axes, to prevent "remapping the remapper."
+-   **Deadzone Enforcement**: Analog inputs must be filtered through a deadzone to prevent "stick drift" from triggering unintentional keyboard events.
+-   **Unmapped Pass-through**: If a physical button has no mapping defined in the active Profile, it is silently discarded; it does not block other inputs or cause errors.

--- a/docs/v0.1.0/phase-2/SYSTEM_OVERVIEW.md
+++ b/docs/v0.1.0/phase-2/SYSTEM_OVERVIEW.md
@@ -1,0 +1,38 @@
+# System Overview
+
+BlazeRemap is a Linux-based input remapping daemon designed to translate physical gamepad inputs—including buttons and axes—into virtual keyboard events. By intercepting raw hardware signals and synthesizing keystrokes through the kernel's uinput interface, the system enables users to utilize controllers in environments or applications that natively support only keyboard input. It prioritizes low-latency execution and a clean separation between hardware-specific event handling and domain-specific mapping logic.
+
+## Non-goals
+- **Reverse Remapping**: The system does not attempt to map keyboard or mouse inputs into virtual gamepad signals.
+- **Complex Macro Scripting**: There is no support for timed sequences, combos, or conditional scripting; mappings are currently direct or state-based translations.
+- **Graphical Configuration**: The system is strictly CLI-driven and does not provide a GUI for mapping management.
+- **Cross-Platform Portability**: The architecture is fundamentally coupled to Linux-specific subsystems (`evdev` and `uinput`) and does not aim for Windows or macOS support.
+
+## High-level Architecture
+```text
+[ Physical Gamepad ] -> (/dev/input/event*) -> [ Input Manager ]
+                                                      |
+                                                      v
+[ Virtual Keyboard ] <- ( /dev/uinput ) <------- [ Event Loop ] <--- [ Mapping Engine ] <--- [ Profile ]
+```
+
+## Primary Data Flow
+1. **Detection**: The Input Manager identifies and opens physical hardware devices via `evdev`.
+2. **Ingestion**: The Event Loop polls the device, converting raw hardware interrupts into normalized domain events.
+3. **Translation**: The Mapping Engine evaluates the normalized events against a loaded Profile (TOML-based) to determine the intended virtual output.
+4. **Synthesis**: The Virtual Keyboard receives instructions to emit specific keycodes, which are injected into the kernel's input subsystem via `uinput`.
+
+## Key Invariants
+- **Axis State Persistence**: The system must track the state of analog axes (like D-Pads) to ensure that a "Release" event is synthesized when an axis returns to neutral or switches direction, preventing stuck keys.
+- **Single Profile Active**: A single execution instance maintains exactly one active mapping profile per device.
+- **Event Ordering**: Output events must be emitted in the same chronological order as their causal input events to maintain input integrity.
+
+## Operational Constraints
+- **Device Permissions**: The process requires read access to `/dev/input/` and write access to `/dev/uinput`, typically requiring specific group memberships (`input`, `uinput`) or elevated privileges.
+- **Exclusive Access**: While the system reads gamepad events, it does not necessarily "grab" the device exclusively unless configured, meaning raw gamepad events may still reach other applications.
+- **Kernel Dependency**: Relies on the availability of the `uinput` kernel module being loaded.
+
+## Assumptions
+- The hardware device is recognized by the Linux kernel as a standard `evdev` input device.
+- The user has provided or is using a profile compatible with the specific layout of their controller.
+- The host system provides a stable monotonic clock for latency tracking and event synchronization.

--- a/docs/v0.1.0/phase-2/phase-2-task-9-performance-results.md
+++ b/docs/v0.1.0/phase-2/phase-2-task-9-performance-results.md
@@ -1,0 +1,25 @@
+## Task 9: Latency Measurement & Optimization ✅
+
+### Performance Results
+
+**Software Processing Latency (BlazeRemap Overhead):**
+- Average: **82µs (0.082ms)**
+- Minimum: **1µs**
+- Maximum: **126µs (0.126ms)**
+
+**Meets Requirements:**
+- ✅ Target: <1ms average → Achieved: 0.082ms (12x better!)
+- ✅ No spikes >16ms → Max observed: 0.126ms
+- ✅ Acceptable for competitive gaming at 240Hz
+
+**Connection Type Impact:**
+- USB (1000Hz polling): Total latency ~1-8ms (hardware + software)
+- Bluetooth: Total latency ~30-100ms (protocol limitation)
+
+**Recommendation:** Use wired USB connection for competitive gaming.
+
+**Optimization Notes:**
+- Removed per-event logging from hot path
+- Minimal allocations in event processing
+- Blocking I/O provides best performance for this use case
+- Release build with LTO enabled

--- a/src/platform/linux/gamepad.rs
+++ b/src/platform/linux/gamepad.rs
@@ -24,7 +24,6 @@ const ELITE_PADDLE_COUNT: usize = 4;
 /// real gamepads (e.g., Steam Virtual Gamepad, remote desktop devices).
 /// This provides a final safety check based on device naming.
 ///
-/// Mirrors: isExcludedByName() from Go
 fn is_excluded_by_name(name: &str) -> bool {
     let name_lower = name.to_lowercase();
 


### PR DESCRIPTION
- create 4 files inside docs/:
  - SYSTEM_OVERVIEW.md`: Explains the system's core purpose as a Linux input remapper, outlining the high-level data flow from physical hardware to virtual synthesis, along with operational constraints and non-goals.
  - `ARCHITECTURE.md`: Details the **Hexagonal (Ports and Adapters)** structure, defining the boundaries between the core domain, the platform-specific adapters (Linux `evdev`/`uinput`), and the CLI driver.
  - `DOMAIN_MODEL.md`: Extracts the implicit domain concepts like `MappingRules`, `Axis State Machines`, and `Profiles`, providing a clear terminology mapping from code to business meaning.
  - `DECISIONS.md`: Records and rationalizes major architectural choices, such as the use of a synchronous event loop for low latency and the reliance on `uinput` for universal input emulation.
- update README.md that reflect the result of Phase 2